### PR TITLE
Fix displaying and copying whitespaces in result

### DIFF
--- a/regex-generator-web/src/main/resources/regex-generator.css
+++ b/regex-generator-web/src/main/resources/regex-generator.css
@@ -122,5 +122,5 @@ form * .rg-check-row {
 }
 
 #rg_result_display {
-  white-space: pre;
+  white-space: pre-wrap;
 }

--- a/regex-generator-web/src/main/resources/regex-generator.css
+++ b/regex-generator-web/src/main/resources/regex-generator.css
@@ -120,3 +120,7 @@ form * .rg-check-row {
   margin: 0;
   background-color: white;
 }
+
+#rg_result_display {
+  white-space: pre;
+}


### PR DESCRIPTION
The default example expression `2020-03-12T13:34:56.123Z INFO  [org.example.Class]: This is a #simple #logline containing a 'value'.` contains two whitespaces after `INFO`, though they're not shown correctly in step 3 and even the copy button does not work as expected.

This PR adds the CSS property `white-space: pre-wrap` to make sure, all characters are shown as expected.