### PR TITLE
Fix scrolling match presentation overflow

### DIFF
--- a/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/js/JQuery.kt
+++ b/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/js/JQuery.kt
@@ -14,10 +14,13 @@ external class JQuery {
     fun parent(): JQuery
     fun remove(): JQuery
 
+    fun find(selector: String): JQuery
+
     fun attr(name: String, newValue: Any = definedExternally): Any?
     fun css(css: Any)
     fun height(): Int
     fun each(function: ((Int, HTMLElement) -> Unit))
 
     fun animate(properties: Json, duration: Int = definedExternally, easing: String = definedExternally)
+    fun stop()
 }

--- a/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/js/JQuery.kt
+++ b/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/js/JQuery.kt
@@ -1,23 +1,23 @@
 package org.olafneumann.regex.generator.js
 
 import org.w3c.dom.HTMLElement
+import kotlin.js.Json
 
 @JsName("$")
 external fun jQuery(id: String): JQuery
-
+@JsName("$")
 external fun jQuery(element: HTMLElement): JQuery
 
-external class JQuery() {
+external class JQuery {
     fun on(type: String, callback: () -> Unit)
-    fun show(): JQuery
     fun hide(): JQuery
     fun parent(): JQuery
     fun remove(): JQuery
-    fun removeClass(className: String = definedExternally)
-    fun addClass(className: String = definedExternally)
 
     fun attr(name: String, newValue: Any = definedExternally): Any?
     fun css(css: Any)
     fun height(): Int
     fun each(function: ((Int, HTMLElement) -> Unit))
+
+    fun animate(properties: Json, duration: Int = definedExternally, easing: String = definedExternally)
 }

--- a/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/js/JQuery.kt
+++ b/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/js/JQuery.kt
@@ -5,7 +5,6 @@ import org.w3c.dom.HTMLElement
 @JsName("$")
 external fun jQuery(id: String): JQuery
 
-//fun jQuery(element: HTMLElement) = jQuery("#${element.id}")
 external fun jQuery(element: HTMLElement): JQuery
 
 external class JQuery() {
@@ -17,8 +16,7 @@ external class JQuery() {
     fun removeClass(className: String = definedExternally)
     fun addClass(className: String = definedExternally)
 
-    fun attr(name: String): Any
-    fun attr(name: String, newValue: Any)
+    fun attr(name: String, newValue: Any = definedExternally): Any?
     fun css(css: Any)
     fun height(): Int
     fun each(function: ((Int, HTMLElement) -> Unit))

--- a/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/js/JQuery.kt
+++ b/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/js/JQuery.kt
@@ -5,7 +5,8 @@ import org.w3c.dom.HTMLElement
 @JsName("$")
 external fun jQuery(id: String): JQuery
 
-fun jQuery(element: HTMLElement) = jQuery("#${element.id}")
+//fun jQuery(element: HTMLElement) = jQuery("#${element.id}")
+external fun jQuery(element: HTMLElement): JQuery
 
 external class JQuery() {
     fun on(type: String, callback: () -> Unit)
@@ -15,4 +16,10 @@ external class JQuery() {
     fun remove(): JQuery
     fun removeClass(className: String = definedExternally)
     fun addClass(className: String = definedExternally)
+
+    fun attr(name: String): Any
+    fun attr(name: String, newValue: Any)
+    fun css(css: Any)
+    fun height(): Int
+    fun each(function: ((Int, HTMLElement) -> Unit))
 }

--- a/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/ui/HtmlView.kt
+++ b/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/ui/HtmlView.kt
@@ -15,6 +15,7 @@ import kotlinx.browser.document
 import kotlinx.dom.addClass
 import kotlinx.dom.clear
 import kotlinx.dom.removeClass
+import kotlin.math.max
 
 class HtmlView(
     private val presenter: DisplayContract.Controller
@@ -113,7 +114,7 @@ class HtmlView(
         matchPresenterToRowIndex.putAll(distributeToRows(matches))
         // Create HTML elements
         val rowElements = mutableMapOf<Int, HTMLDivElement>()
-        matchPresenterToRowIndex.map { (matchPresenter, rowIndex) ->
+        matchPresenterToRowIndex.forEach {  (matchPresenter, rowIndex) ->
             rowElements[rowIndex] = rowElements[rowIndex] ?: createRowElement()
             val rowElement = rowElements[rowIndex]!!
 
@@ -180,6 +181,18 @@ class HtmlView(
                     }
                 })
         }
+
+        // now compute the max height of the overlays
+        // use it to set the height of the step-2-field
+        // https://stackoverflow.com/questions/2345784/jquery-get-height-of-hidden-element-in-jquery
+        val recognizers = jQuery(".rg-match-item-overlay")
+        val previousCss = recognizers.attr("style")
+        recognizers.css("position:absolute;visibility:hidden;display:block !important;")
+        var height = 0
+        recognizers.each { jq -> height = max(height, jq.height()) }
+        recognizers.attr("style", previousCss ?: "")
+        val rowsHeight = jQuery(".rg-match-row").height() * rowElements.size
+        rowContainer.style.height = "${rowsHeight + height + 8}px"
     }
 
     private fun distributeToRows(matches: Collection<MatchPresenter>): Map<MatchPresenter, Int> {
@@ -306,6 +319,9 @@ class HtmlView(
         const val ID_DIV_LANGUAGES = "rg_language_accordion"
         const val ID_ANCHOR_REGEX101 = "rg_anchor_regex101"
         const val ID_ANCHOR_REGEXR = "rg_anchor_regexr"
+
+        fun JQuery.each(function: (JQuery) -> Unit) =
+            each { _, htmlElement -> function(jQuery(htmlElement)) }
     }
 }
 

--- a/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/ui/HtmlView.kt
+++ b/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/ui/HtmlView.kt
@@ -15,6 +15,7 @@ import kotlinx.browser.document
 import kotlinx.dom.addClass
 import kotlinx.dom.clear
 import kotlinx.dom.removeClass
+import kotlin.js.json
 import kotlin.math.max
 
 class HtmlView(
@@ -126,8 +127,7 @@ class HtmlView(
             applyListenersForUserInput(matchPresenter, element, cssClass)
         }
 
-        // set the size of match presenter container
-        rowContainer.style.height = "${computeMatchPresenterAreaHeight(rowElements.size)}px"
+        animateResultDisplaySize(numberOfRows = rowElements.size)
     }
 
     private fun distributeToRows(matches: Collection<MatchPresenter>): Map<MatchPresenter, Int> {
@@ -212,6 +212,11 @@ class HtmlView(
                     matchPresenter.forEachIndexInRanges { index -> inputCharacterSpans[index].removeClass(cssClass) }
                 }
             })
+    }
+
+    private fun animateResultDisplaySize(numberOfRows: Int) {
+        val newHeight = "${computeMatchPresenterAreaHeight(numberOfRows)}px"
+        jQuery(rowContainer).animate(json("height" to newHeight), duration = 350)
     }
 
     private fun computeMatchPresenterAreaHeight(numberOfRows: Int): Int {

--- a/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/ui/HtmlView.kt
+++ b/regex-generator-web/src/main/kotlin/org/olafneumann/regex/generator/ui/HtmlView.kt
@@ -100,10 +100,9 @@ class HtmlView(
     override fun showResults(matches: Collection<MatchPresenter>) {
         // TODO remove CSS class iterator
         val indices = mutableMapOf<Int, Int>()
-        val classes = listOf("primary", "success", "danger", "warning")
         fun nextCssClass(row: Int): String {
             indices[row] = (indices[row] ?: row) + 1
-            return "bg-${classes[indices[row]!! % classes.size]}"
+            return MATCH_PRESENTER_CSS_CLASS[indices[row]!! % MATCH_PRESENTER_CSS_CLASS.size]
         }
 
 
@@ -115,84 +114,20 @@ class HtmlView(
         // Create HTML elements
         val rowElements = mutableMapOf<Int, HTMLDivElement>()
         matchPresenterToRowIndex.forEach {  (matchPresenter, rowIndex) ->
+            // assign required stuff
             rowElements[rowIndex] = rowElements[rowIndex] ?: createRowElement()
             val rowElement = rowElements[rowIndex]!!
-
-            // create the corresponding regex element
-            val element = document.create.div(classes = CLASS_MATCH_ITEM) {
-                div(classes = "rg-match-item-overlay") {
-                    matchPresenter.recognizerMatches.forEach { match ->
-                        div(classes = "rg-recognizer") {
-                            a {
-                                +match.title
-                                onClickFunction = { event ->
-                                    presenter.onSuggestionClick(match)
-                                    event.stopPropagation()
-                                }
-                            }
-                        }
-                    }
-                }
-                onClickFunction = {
-                    when {
-                        matchPresenter.selected ->
-                            matchPresenter.selectedMatch?.let { presenter.onSuggestionClick(it) }
-                        matchPresenter.recognizerMatches.size == 1 ->
-                            presenter.onSuggestionClick(matchPresenter.recognizerMatches.iterator().next())
-                    }
-                }
-            }
-            rowElement.appendChild(element)
-            // adjust styling
             val cssClass = nextCssClass(rowIndex)
-            element.addClass(cssClass)
-            element.style.left = matchPresenter.first.toCharacterUnits()
-            element.style.width = matchPresenter.length.toCharacterUnits()
-            if (matchPresenter.ranges.size == 2) {
-                element.style.borderLeftWidth =
-                    (matchPresenter.ranges[0].last - matchPresenter.ranges[0].first + 1).toCharacterUnits()
-                element.style.borderRightWidth =
-                    (matchPresenter.ranges[1].last - matchPresenter.ranges[1].first + 1).toCharacterUnits()
-            }
-            // add listeners to handle display correctly
-            matchPresenter.onSelectedChanged = { selected ->
-                element.classList.toggle(CLASS_ITEM_SELECTED, selected)
-                matchPresenter.forEachIndexInRanges { index ->
-                    inputCharacterSpans[index].classList.toggle(CLASS_CHAR_SELECTED, selected)
-                }
-            }
-            matchPresenter.onDeactivatedChanged =
-                { deactivated -> element.classList.toggle(CLASS_ITEM_NOT_AVAILABLE, deactivated) }
-            element.classList.toggle(CLASS_ITEM_SELECTED, matchPresenter.selected)
-            element.classList.toggle(CLASS_ITEM_NOT_AVAILABLE, matchPresenter.deactivated)
-            // add listeners to react on user input
-            element.addEventListener(
-                EVENT_MOUSE_ENTER,
-                {
-                    if (matchPresenter.availableForHighlight) {
-                        matchPresenter.forEachIndexInRanges { index -> inputCharacterSpans[index].addClass(cssClass) }
-                    }
-                })
-            element.addEventListener(
-                EVENT_MOUSE_LEAVE,
-                {
-                    if (matchPresenter.availableForHighlight) {
-                        matchPresenter.forEachIndexInRanges { index -> inputCharacterSpans[index].removeClass(cssClass) }
-                    }
-                })
+
+            // create the corresponding match presenter element
+            val element = createMatchPresenterElement(matchPresenter)
+            rowElement.appendChild(element)
+            applyCssStyling(matchPresenter, element, cssClass)
+            applyListenersForUserInput(matchPresenter, element, cssClass)
         }
 
-        // now compute the max height of the overlays
-        // use it to set the height of the step-2-field
-        // https://stackoverflow.com/questions/2345784/jquery-get-height-of-hidden-element-in-jquery
-        val recognizers = jQuery(".rg-match-item-overlay")
-        val previousCss = recognizers.attr("style")
-        recognizers.css("position:absolute;visibility:hidden;display:block !important;")
-        var height = 0
-        recognizers.each { jq -> height = max(height, jq.height()) }
-        recognizers.attr("style", previousCss ?: "")
-        val rowsHeight = jQuery(".rg-match-row").height() * rowElements.size
-        rowContainer.style.height = "${rowsHeight + height + 8}px"
+        // set the size of match presenter container
+        rowContainer.style.height = "${computeMatchPresenterAreaHeight(rowElements.size)}px"
     }
 
     private fun distributeToRows(matches: Collection<MatchPresenter>): Map<MatchPresenter, Int> {
@@ -212,9 +147,84 @@ class HtmlView(
             }.toMap()
     }
 
-
     private fun createRowElement(): HTMLDivElement =
         rowContainer.appendChild(document.create.div(classes = CLASS_MATCH_ROW)) as HTMLDivElement
+
+    private fun createMatchPresenterElement(matchPresenter: MatchPresenter): HTMLDivElement =
+        document.create.div(classes = CLASS_MATCH_ITEM) {
+            div(classes = "rg-match-item-overlay") {
+                matchPresenter.recognizerMatches.forEach { match ->
+                    div(classes = "rg-recognizer") {
+                        a {
+                            +match.title
+                            onClickFunction = { event ->
+                                presenter.onSuggestionClick(match)
+                                event.stopPropagation()
+                            }
+                        }
+                    }
+                }
+            }
+            onClickFunction = {
+                when {
+                    matchPresenter.selected ->
+                        matchPresenter.selectedMatch?.let { presenter.onSuggestionClick(it) }
+                    matchPresenter.recognizerMatches.size == 1 ->
+                        presenter.onSuggestionClick(matchPresenter.recognizerMatches.iterator().next())
+                }
+            }
+        }
+
+    private fun applyCssStyling(matchPresenter: MatchPresenter, element: HTMLDivElement, cssClass: String) {
+        element.addClass(cssClass)
+        element.style.left = matchPresenter.first.toCharacterUnits()
+        element.style.width = matchPresenter.length.toCharacterUnits()
+        if (matchPresenter.ranges.size == 2) {
+            element.style.borderLeftWidth =
+                (matchPresenter.ranges[0].last - matchPresenter.ranges[0].first + 1).toCharacterUnits()
+            element.style.borderRightWidth =
+                (matchPresenter.ranges[1].last - matchPresenter.ranges[1].first + 1).toCharacterUnits()
+        }
+        element.classList.toggle(CLASS_ITEM_SELECTED, matchPresenter.selected)
+        element.classList.toggle(CLASS_ITEM_NOT_AVAILABLE, matchPresenter.deactivated)
+        matchPresenter.onSelectedChanged = { selected ->
+            element.classList.toggle(CLASS_ITEM_SELECTED, selected)
+            matchPresenter.forEachIndexInRanges { index ->
+                inputCharacterSpans[index].classList.toggle(CLASS_CHAR_SELECTED, selected)
+            }
+        }
+        matchPresenter.onDeactivatedChanged =
+            { deactivated -> element.classList.toggle(CLASS_ITEM_NOT_AVAILABLE, deactivated) }
+    }
+
+    private fun applyListenersForUserInput(matchPresenter: MatchPresenter, element: HTMLDivElement, cssClass: String) {
+        element.addEventListener(
+            EVENT_MOUSE_ENTER,
+            {
+                if (matchPresenter.availableForHighlight) {
+                    matchPresenter.forEachIndexInRanges { index -> inputCharacterSpans[index].addClass(cssClass) }
+                }
+            })
+        element.addEventListener(
+            EVENT_MOUSE_LEAVE,
+            {
+                if (matchPresenter.availableForHighlight) {
+                    matchPresenter.forEachIndexInRanges { index -> inputCharacterSpans[index].removeClass(cssClass) }
+                }
+            })
+    }
+
+    private fun computeMatchPresenterAreaHeight(numberOfRows: Int): Int {
+        // https://stackoverflow.com/questions/2345784/jquery-get-height-of-hidden-element-in-jquery
+        val recognizers = jQuery(".rg-match-item-overlay")
+        val previousCss = recognizers.attr("style")
+        recognizers.css("position:absolute;visibility:hidden;display:block !important;")
+        var maxHeightOfMatchPresenters = 0
+        recognizers.each { jq -> maxHeightOfMatchPresenters = max(maxHeightOfMatchPresenters, jq.height()) }
+        recognizers.attr("style", previousCss ?: "")
+        val rowsHeight = jQuery(".rg-match-row").height() * numberOfRows
+        return rowsHeight + maxHeightOfMatchPresenters + MAGIC_HEIGHT
+    }
 
     override var options: RecognizerCombiner.Options
         get() = RecognizerCombiner.Options(
@@ -319,6 +329,9 @@ class HtmlView(
         const val ID_DIV_LANGUAGES = "rg_language_accordion"
         const val ID_ANCHOR_REGEX101 = "rg_anchor_regex101"
         const val ID_ANCHOR_REGEXR = "rg_anchor_regexr"
+
+        val MATCH_PRESENTER_CSS_CLASS = listOf("bg-primary", "bg-success", "bg-danger", "bg-warning")
+        const val MAGIC_HEIGHT = 8
 
         fun JQuery.each(function: (JQuery) -> Unit) =
             each { _, htmlElement -> function(jQuery(htmlElement)) }

--- a/regex-generator-web/src/main/resources/index.html
+++ b/regex-generator-web/src/main/resources/index.html
@@ -299,9 +299,8 @@
         </footer>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"
-        integrity="sha384-J6qa4849blE2+poT4WnyKhv5vZF5SrPo0iEjwBvKU7imGFAV0wwj1yYfoRSJoZ+n"
-        crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"
+        integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"
         integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo"
         crossorigin="anonymous"></script>

--- a/regex-generator-web/src/main/resources/regex-generator.css
+++ b/regex-generator-web/src/main/resources/regex-generator.css
@@ -16,9 +16,8 @@
 }
 
 .rg-match-container {
-  /*overflow-x: auto;*/
+  overflow-x: auto;
   width: 100%;
-  padding-bottom: 1.5em;
 }
 
 .rg-match-row {


### PR DESCRIPTION
Change the display of the recognized matchers. The content will now scroll inside the main div und will not overflow the page.
Closes #84 