### PR TITLE
Make local Java and C# variables constant

### DIFF
--- a/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
+++ b/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
@@ -105,11 +105,11 @@ internal class JavaCodeGenerator : SimpleReplacingCodeGenerator(
                 |import java.util.regex.Matcher;
                 |
                 |public class Sample {
-                |    public boolean useRegex(String input) {
+                |    public static boolean useRegex(final String input) {
                 |        // Compile regular expression
-                |        Pattern pattern = Pattern.compile("%1${'$'}s"%2${'$'}s);
+                |        final Pattern pattern = Pattern.compile("%1${'$'}s"%2${'$'}s);
                 |        // Match regex against input
-                |        Matcher matcher = pattern.matcher(input);
+                |        final Matcher matcher = pattern.matcher(input);
                 |        // Use results...
                 |        return matcher.matches();
                 |    }
@@ -233,7 +233,7 @@ public class Sample
 {
     public static void useRegex(String input)
     {
-        Regex regex = new Regex("%1${'$'}s"%2${'$'}s);
+        const Regex regex = new Regex("%1${'$'}s"%2${'$'}s);
         return regex.IsMatch(input);
     }
 }"""


### PR DESCRIPTION
@noxone, in our own code we tend to make variables final as long it's possible. Should the code snippets respect that, too?