### PR TITLE
Generic language name escape

### DIFF
--- a/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
+++ b/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
@@ -1,6 +1,7 @@
 package org.olafneumann.regex.generator.output
 
 import org.olafneumann.regex.generator.js.encodeURIComponent
+import org.olafneumann.regex.generator.output.CodeGenerator.Companion.codePointString
 import org.olafneumann.regex.generator.regex.RecognizerCombiner
 import org.olafneumann.regex.generator.regex.RegexCache
 
@@ -19,7 +20,7 @@ interface CodeGenerator {
             , VisualBasicNetCodeGenerator()
         ).sortedBy { it.languageName.lowercase() }
 
-        private val String.codePointString: String
+        internal val String.codePointString: String
             get() {
                 return if (isNotEmpty()) {
                     "_u${this[0].code.toString()}_"
@@ -27,6 +28,15 @@ interface CodeGenerator {
                     ""
                 }
             }
+
+        internal val String.htmlIdCompatible: String
+            get() = this
+                .replace(" ", "__")
+                .replace("-", "_minus_")
+                .replace(".", "_dot_")
+                .replace("+", "_plus_")
+                .replace("#", "_sharp_")
+                .replace(regex = Regex("[^_A-Za-z0-9]"), transform = { it.value.codePointString })
     }
 
     val languageName: String
@@ -34,13 +44,7 @@ interface CodeGenerator {
     val highlightLanguage: String
 
     val uniqueName: String
-        get() = languageName
-            .replace(" ", "__")
-            .replace("-", "_minus_")
-            .replace(".", "_dot_")
-            .replace("+", "_plus_")
-            .replace("#", "_sharp_")
-            .replace(regex = Regex("[^_A-Za-z0-9]"), transform = { it.value.codePointString })
+        get() = languageName.htmlIdCompatible
 
     fun generateCode(pattern: String, options: RecognizerCombiner.Options): GeneratedSnippet
 

--- a/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
+++ b/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
@@ -18,6 +18,15 @@ interface CodeGenerator {
             , SwiftCodeGenerator()
             , VisualBasicNetCodeGenerator()
         ).sortedBy { it.languageName.lowercase() }
+
+        private val String.codePointString: String
+            get() {
+                return if (isNotEmpty()) {
+                    "_u${this[0].code.toString()}_"
+                } else {
+                    ""
+                }
+            }
     }
 
     val languageName: String
@@ -31,6 +40,7 @@ interface CodeGenerator {
             .replace(".", "_dot_")
             .replace("+", "_plus_")
             .replace("#", "_sharp_")
+            .replace(regex = Regex("[^_A-Za-z0-9]"), transform = { it.value.codePointString })
 
     fun generateCode(pattern: String, options: RecognizerCombiner.Options): GeneratedSnippet
 

--- a/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
+++ b/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
@@ -1,7 +1,6 @@
 package org.olafneumann.regex.generator.output
 
 import org.olafneumann.regex.generator.js.encodeURIComponent
-import org.olafneumann.regex.generator.output.CodeGenerator.Companion.codePointString
 import org.olafneumann.regex.generator.regex.RecognizerCombiner
 import org.olafneumann.regex.generator.regex.RegexCache
 
@@ -20,10 +19,10 @@ interface CodeGenerator {
             , VisualBasicNetCodeGenerator()
         ).sortedBy { it.languageName.lowercase() }
 
-        internal val String.codePointString: String
+        private val String.codePointString: String
             get() {
                 return if (isNotEmpty()) {
-                    "_u${this[0].code.toString()}_"
+                    "_u${this[0].code}_"
                 } else {
                     ""
                 }

--- a/src/test/kotlin/org/olafneumann/regex/generator/output/CodeGeneratorTest.kt
+++ b/src/test/kotlin/org/olafneumann/regex/generator/output/CodeGeneratorTest.kt
@@ -1,18 +1,6 @@
 package org.olafneumann.regex.generator.output
 
-import org.olafneumann.regex.generator.output.CSharpCodeGenerator
-import org.olafneumann.regex.generator.output.CodeGenerator
-import org.olafneumann.regex.generator.output.CodeGenerator.Companion.codePointString
 import org.olafneumann.regex.generator.output.CodeGenerator.Companion.htmlIdCompatible
-import org.olafneumann.regex.generator.output.GrepCodeGenerator
-import org.olafneumann.regex.generator.output.JavaCodeGenerator
-import org.olafneumann.regex.generator.output.JavaScriptCodeGenerator
-import org.olafneumann.regex.generator.output.KotlinCodeGenerator
-import org.olafneumann.regex.generator.output.PhpCodeGenerator
-import org.olafneumann.regex.generator.output.PythonCodeGenerator
-import org.olafneumann.regex.generator.output.RubyCodeGenerator
-import org.olafneumann.regex.generator.output.SwiftCodeGenerator
-import org.olafneumann.regex.generator.output.VisualBasicNetCodeGenerator
 import org.olafneumann.regex.generator.regex.RecognizerCombiner
 import org.olafneumann.regex.generator.regex.RecognizerCombiner.Options
 import kotlin.test.Test

--- a/src/test/kotlin/org/olafneumann/regex/generator/output/CodeGeneratorTest.kt
+++ b/src/test/kotlin/org/olafneumann/regex/generator/output/CodeGeneratorTest.kt
@@ -2,6 +2,8 @@ package org.olafneumann.regex.generator.output
 
 import org.olafneumann.regex.generator.output.CSharpCodeGenerator
 import org.olafneumann.regex.generator.output.CodeGenerator
+import org.olafneumann.regex.generator.output.CodeGenerator.Companion.codePointString
+import org.olafneumann.regex.generator.output.CodeGenerator.Companion.htmlIdCompatible
 import org.olafneumann.regex.generator.output.GrepCodeGenerator
 import org.olafneumann.regex.generator.output.JavaCodeGenerator
 import org.olafneumann.regex.generator.output.JavaScriptCodeGenerator
@@ -24,6 +26,16 @@ class CodeGeneratorTest {
 
     private fun generateRegex(input: String): String =
         RecognizerCombiner.combineMatches(inputText = input, selectedMatches = emptyList(), options = Options()).pattern
+
+    @Test
+    fun testLanguageNameReplacement() {
+        val given = ".abc_DEF-13 37#+xù\$x\\abc"
+        val expected = "_dot_abc_DEF_minus_13__37_sharp__plus_x_u249__u36_x_u92_abc"
+
+        val actual = given.htmlIdCompatible
+
+        assertEquals(expected, actual)
+    }
 
     @Test
     fun testGenerator_Regex() {


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Readme.md has been updated to reflect changes.
- [x] Build (`./gradlew build`) was run locally and any changes were pushed


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Previously language names only escaped certain characters. If a new language would be added that contains a character that is illegal in an HTML ID and is not yet explicitly escaped it would break the page. 

Issue Number: #188 


## What is the new behavior?

- The new behavior generically escapes all characters that are not valid in an HTML ID.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
