### PR TITLE
fix: python flag should be in compile, not match

### DIFF
--- a/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
+++ b/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
@@ -398,8 +398,8 @@ internal class PythonCodeGenerator : SimpleReplacingCodeGenerator(
     templateCode = """import re
 
 def useRegex(input):
-    pattern = re.compile(r"%1${'$'}s")
-    return pattern.match(input%2${'$'}s)"""
+    pattern = re.compile(r"%1${'$'}s, %2${'$'}s")
+    return pattern.match(input)"""
 ) {
 
     override fun transformPattern(pattern: String, options: RecognizerCombiner.Options): String =

--- a/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
+++ b/src/main/kotlin/org/olafneumann/regex/generator/output/CodeGenerator.kt
@@ -398,7 +398,7 @@ internal class PythonCodeGenerator : SimpleReplacingCodeGenerator(
     templateCode = """import re
 
 def useRegex(input):
-    pattern = re.compile(r"%1${'$'}s, %2${'$'}s")
+    pattern = re.compile(r"%1${'$'}s"%2${'$'}s)
     return pattern.match(input)"""
 ) {
 

--- a/src/test/kotlin/org/olafneumann/regex/generator/output/CodeGeneratorTest.kt
+++ b/src/test/kotlin/org/olafneumann/regex/generator/output/CodeGeneratorTest.kt
@@ -156,8 +156,8 @@ end"""
         codeGenerator = PythonCodeGenerator(), expected = """import re
 
 def useRegex(input):
-    pattern = re.compile(r"abc\\.\\\\\\${'$'}hier \"und\" / 'da'\\(\\[\\)\\.")
-    return pattern.match(input, re.IGNORECASE)"""
+    pattern = re.compile(r"abc\\.\\\\\\${'$'}hier \"und\" / 'da'\\(\\[\\)\\.", re.IGNORECASE)
+    return pattern.match(input)"""
     )
 
     @Test


### PR DESCRIPTION
Match second argument aren't flags (such as re.IGNORECASE), but position to start the regex on.

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [❌] Tests for the changes have been added (for bug fixes / features)
- [✅] Readme.md has been updated to reflect changes (no changes to reflect on readme)
- [❌] Build (`./gradlew build`) was run locally and any changes were pushed


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [✅] Bugfix
- [❌] Feature
- [❌] Code style update (formatting, renaming)
- [❌] Refactoring (no functional changes, no api changes)
- [❌] Build related changes
- [❌] Documentation content changes
- [❌] Other (please describe): 


## What is the current behavior?
By default, generator activate IGNORECASE flag. That flag isn't working, at least on Python generator, because it is not in the correct place. The result is a "valid" regexpr which uses a flag enum for a completely different parameter : position.

Issue Number: 1 or more depending on other languages implementations

Code generated :
```python
>>> def useRegex(input):
...     pattern = re.compile(r"[a-zA-Z]+")
...     return pattern.match(input, re.IGNORECASE)
... 
>>> useRegex("teST")
<re.Match object; span=(2, 4), match='ST'>
>>> useRegex("te") # no match
```


## What is the new behavior?
I didn't test but quickly wrote a fix which would add the options flags in the correct sentence (re.compile and not str.match).

Intended behavior :
```python

>>> def useRegex(input):
...     pattern = re.compile(r"[a-zA-Z]+", re.IGNORECASE)
...     return pattern.match(input)
... 
>>> useRegex("teST")
<re.Match object; span=(0, 4), match='teST'>
>>> useRegex("te")
<re.Match object; span=(0, 2), match='te'>
```

## Other information

