### PR TITLE
fix error about snap version of firefox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,14 @@ WORKDIR /app
 COPY . .
 
 # Install Firefox
-RUN apt-get update && apt-get install -y \
+RUN echo 'Package: firefox' > /etc/apt/preferences.d/firefox-no-snap  && \
+	echo 'Pin: origin "*.ubuntu.com"' >> /etc/apt/preferences.d/firefox-no-snap  && \ 
+	echo 'Pin: origin "*.ubuntu.com"' >> /etc/apt/preferences.d/firefox-no-snap  && \
+	echo 'Pin-Priority: -1' >> /etc/apt/preferences.d/firefox-no-snap && \
+	apt-get update && apt purge firefox &&\
+	apt-get install -y software-properties-common && \
+	add-apt-repository ppa:mozillateam/ppa && \
+	apt-get update && apt-get install -y \
 	firefox \
 	--no-install-recommends
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [NA] Readme.md has been updated to reflect changes.
- [x] Build (`./gradlew build`) was run locally and any changes were pushed


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 261


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
in dockerfile, we pin firefox version to the ppa version instead of the snap version, we purge firefox, and install it
https://www.reddit.com/r/Ubuntu/comments/i7ue26/is_there_a_way_to_use_the_nonsnap_version_of/
-
-
-

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
