### PR TITLE
Remove yarn warning for compiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,3 +69,9 @@ kotlin {
         binaries.executable()
     }
 }
+
+// found here: https://youtrack.jetbrains.com/issue/KT-52578
+// and here:   http://kotlin.liying-cn.net/docs/reference_zh/js/js-project-setup.html
+rootProject.plugins.withType(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin) {
+  rootProject.extensions.getByType(org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension).ignoreScripts = false
+}


### PR DESCRIPTION
Removes the compiler warning:
```
> Task :kotlinNpmInstall
warning Ignored scripts due to flag.
```