### PR TITLE
#506 prevent hyphen at start of line for grep

### DIFF
--- a/src/main/kotlin/org/olafneumann/regex/generator/output/GrepCodeGenerator.kt
+++ b/src/main/kotlin/org/olafneumann/regex/generator/output/GrepCodeGenerator.kt
@@ -8,6 +8,7 @@ class GrepCodeGenerator : SimpleReplacingCodeGenerator(
 
     override fun transformPattern(pattern: String): String =
         pattern.replace("'", "'\"'\"'")
+            .replace(regex = Regex("^-"), "\\-")
 
     override fun generateOptionsCode(options: CodeGeneratorOptions) =
         options.combine(valueForCaseInsensitive = "-i", separator = " ", prefix = " ")

--- a/src/test/kotlin/org/olafneumann/regex/generator/output/CodeGeneratorTest.kt
+++ b/src/test/kotlin/org/olafneumann/regex/generator/output/CodeGeneratorTest.kt
@@ -41,9 +41,10 @@ class CodeGeneratorTest {
     private fun testLanguageGenerator(
         codeGenerator: CodeGenerator,
         options: CodeGeneratorOptions = CodeGeneratorOptions(),
+        input: String = given,
         expected: String
     ) {
-        val regex = generateRegex(given)
+        val regex = generateRegex(input)
         val actual = codeGenerator.generateCode(pattern = regex, options = options).snippet
         assertEquals(expected, actual)
     }
@@ -132,6 +133,14 @@ public class Sample
     fun testGenerator_Grep() = testLanguageGenerator(
         codeGenerator = GrepCodeGenerator(),
         expected = """grep -P -i 'abc\.\\\${'$'}hier "und" / '"'"'da'"'"'\(\[\)\.' [FILE...]"""
+    )
+
+    @Test
+    @Suppress("MaxLineLength")
+    fun testGenerator_Grep_with_hyphen_at_start() = testLanguageGenerator(
+        codeGenerator = GrepCodeGenerator(),
+        input = "-abc",
+        expected = """grep -P -i '\-abc' [FILE...]"""
     )
 
     @Test


### PR DESCRIPTION
## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Readme.md has been updated to reflect changes.
- [x] Build (`./gradlew build`) was run locally and any changes were pushed


## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
The code does _not_ generate a backslash at the beginning for GREP if the regex starts with a hyphen.

Issue Number: #506


## What is the new behavior?
Behaviour is fixed.